### PR TITLE
Revise parameter handling for snippets

### DIFF
--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -439,15 +439,15 @@ const getParameterValues = function (param, values) {
     'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE';
   if (values && typeof values[param.name] !== 'undefined') {
     value = values[param.name];
-  } else if (typeof param.default !== 'undefined') {
-    value = param.default;
+  } else if (typeof param.example !== 'undefined') {
+    value = param.example;
   } else if (
     typeof param.schema !== 'undefined' &&
     typeof param.schema.example !== 'undefined'
   ) {
     value = param.schema.example;
-  } else if (typeof param.example !== 'undefined') {
-    value = param.example;
+  } else if (typeof param.default !== 'undefined') {
+    value = param.default;
   }
 
   return createHarParameterObjects(param, value);

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -438,22 +438,19 @@ const getParameterValues = function (param, values) {
   let value =
     'SOME_' + (param.type || param.schema.type).toUpperCase() + '_VALUE';
   if (values && typeof values[param.name] !== 'undefined') {
-    value =
-      values[param.name] + ''; /* adding a empty string to convert to string */
+    value = values[param.name];
   } else if (typeof param.default !== 'undefined') {
-    value = param.default + '';
+    value = param.default;
   } else if (
     typeof param.schema !== 'undefined' &&
     typeof param.schema.example !== 'undefined'
   ) {
-    value = param.schema.example + '';
+    value = param.schema.example;
   } else if (typeof param.example !== 'undefined') {
-    value = param.example + '';
+    value = param.example;
   }
-  return {
-    name: param.name,
-    value: value,
-  };
+
+  return createHarParameterObjects(param, value)[0];
 };
 
 /**

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -157,7 +157,7 @@ const getDefaultExplodeForStyle = function (style) {
 const getArrayElementSeparator = function (style) {
   let separator = ',';
   if (style === 'spaceDelimited') {
-    separator = '%20';
+    separator = ' ';
   } else if (style === 'pipeDelimited') {
     separator = '|';
   }

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -570,7 +570,11 @@ const getFullPath = function (openApi, path, method) {
       ) {
         if (typeof param.example !== 'undefined') {
           // only if the schema has an example value
-          fullPath = fullPath.replace('{' + param.name + '}', param.example);
+          const parameterValue = createHarParameterObjects(
+            param,
+            param.example
+          )[0].value;
+          fullPath = fullPath.replace('{' + param.name + '}', parameterValue);
         }
       }
     }

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -441,6 +441,8 @@ const getParameterValues = function (param, values) {
     value = values[param.name];
   } else if (typeof param.example !== 'undefined') {
     value = param.example;
+  } else if (typeof param.examples !== 'undefined') {
+    value = Object.values(param.examples)[0].value;
   } else if (
     typeof param.schema !== 'undefined' &&
     typeof param.schema.example !== 'undefined'
@@ -568,12 +570,11 @@ const getFullPath = function (openApi, path, method) {
         typeof param.in !== 'undefined' &&
         param.in.toLowerCase() === 'path'
       ) {
-        if (typeof param.example !== 'undefined') {
+        const parameterValues = getParameterValues(param);
+        if (parameterValues.length > 0) {
           // only if the schema has an example value
-          const parameterValue = createHarParameterObjects(
-            param,
-            param.example
-          )[0].value;
+          // technically parameterValues should only ever have 0 or 1 entries
+          const parameterValue = parameterValues[0].value;
           fullPath = fullPath.replace('{' + param.name + '}', parameterValue);
         }
       }

--- a/openapi-to-har.js
+++ b/openapi-to-har.js
@@ -44,7 +44,7 @@ const createHar = function (openApi, path, method, queryParamValues) {
     headers: getHeadersArray(openApi, path, method),
     queryString: getQueryStrings(openApi, path, method, queryParamValues),
     httpVersion: 'HTTP/1.1',
-    cookies: [],
+    cookies: getCookies(openApi, path, method),
     headersSize: 0,
     bodySize: 0,
   };
@@ -612,6 +612,17 @@ const getFullPath = function (openApi, path, method) {
   });
 
   return fullPath;
+};
+
+/**
+ * Get an array of objects providing sample values for cookies
+ *
+ * @param  {Object} openApi OpenAPI document
+ * @param  {string} path    Key of the path
+ * @param  {string} method  Key of the method
+ */
+const getCookies = function (openApi, path, method) {
+  return getParameterCollectionIn(openApi, path, method, 'cookie');
 };
 
 /**

--- a/test/parameter_example_swagger.json
+++ b/test/parameter_example_swagger.json
@@ -32,6 +32,7 @@
             "description": "tags to filter by",
             "required": false,
             "style": "form",
+            "explode": false,
             "example": ["dog", "cat"],
             "schema": {
               "type": "array",
@@ -84,6 +85,7 @@
           "description": "tags to filter by",
           "required": false,
           "style": "form",
+          "explode": false,
           "example": ["dog", "cat"],
           "schema": {
             "type": "array",
@@ -153,6 +155,7 @@
             "in": "query",
             "description": "A comma-seperated list of species IDs",
             "required": false,
+            "explode": false,
             "example": [1, 2],
             "schema": {
               "type": "array",

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -1,0 +1,281 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "version": "1.0.0",
+        "title": "Swagger Petstore",
+        "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+        "termsOfService": "http://swagger.io/terms/",
+        "contact": {
+            "name": "Swagger API Team",
+            "email": "apiteam@swagger.io",
+            "url": "http://swagger.io"
+        },
+        "license": {
+            "name": "Apache 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+        }
+    },
+    "servers": [
+        {
+            "url": "http://petstore.swagger.io/api"
+        }
+    ],
+    "paths": {
+        "/pets": {
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "objectValue",
+                        "in": "query",
+                        "explode": false,
+                        "example": {
+                            "role": "admin",
+                            "firstName": "Alex",
+                            "age": 34
+                        },
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "example": [
+                            "dog",
+                            "cat"
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "example": 10,
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/animals": {
+            "parameters": [
+                {
+                    "name": "tags",
+                    "in": "query",
+                    "description": "tags to filter by",
+                    "required": false,
+                    "style": "form",
+                    "explode": false,
+                    "example": [
+                        "dog",
+                        "cat"
+                    ],
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                {
+                    "name": "limit",
+                    "in": "query",
+                    "description": "maximum number of results to return",
+                    "example": 10,
+                    "required": false,
+                    "schema": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            ],
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/species": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "query",
+                    "description": "the species id",
+                    "required": false,
+                    "example": 1,
+                    "schema": {
+                        "type": "integer"
+                    }
+                }
+            ],
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "query",
+                        "description": "A comma-seperated list of species IDs",
+                        "required": false,
+                        "explode": false,
+                        "example": [
+                            1,
+                            2
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer"
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Species"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "Pet": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/NewPet"
+                    },
+                    {
+                        "required": [
+                            "id"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "format": "int64"
+                            }
+                        }
+                    }
+                ]
+            },
+            "NewPet": {
+                "required": [
+                    "name"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "tag": {
+                        "type": "string"
+                    }
+                }
+            },
+            "Species": {
+                "items": {
+                    "$ref": "#/components/thing"
+                },
+                "type": "array"
+            },
+            "Thing": {
+                "required": [
+                    "id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    }
+                }
+            },
+            "Error": {
+                "required": [
+                    "code",
+                    "message"
+                ],
+                "properties": {
+                    "code": {
+                        "type": "integer",
+                        "format": "int32"
+                    },
+                    "message": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -198,10 +198,11 @@
                     "required": false,
                     "style": "form",
                     "explode": false,
-                    "example": [
-                        "dog",
-                        "cat"
-                    ],
+                    "examples": {
+                        "firstExample": {
+                            "$ref": "#/components/examples/firstExample"
+                        }
+                    },
                     "schema": {
                         "type": "array",
                         "items": {
@@ -309,6 +310,15 @@
         }
     },
     "components": {
+        "examples": {
+            "firstExample": {
+                "summary": "A first example",
+                "value": [
+                    "dog",
+                    "cat"
+                ]
+            }
+        },
         "schemas": {
             "Pet": {
                 "allOf": [

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -27,8 +27,80 @@
                 "operationId": "getPet",
                 "parameters": [
                     {
-                        "name": "objectValue",
+                        "name": "id",
                         "in": "query",
+                        "explode": false,
+                        "example": {
+                            "role": "admin",
+                            "firstName": "Alex",
+                            "age": 34
+                        },
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    {
+                        "name": "tags",
+                        "in": "query",
+                        "description": "tags to filter by",
+                        "required": false,
+                        "style": "form",
+                        "explode": false,
+                        "example": [
+                            "dog",
+                            "cat"
+                        ],
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "maximum number of results to return",
+                        "example": 10,
+                        "required": false,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "pet response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Pet"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "unexpected error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Error"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/pets/{id}": {
+            "get": {
+                "description": "Get Pets from store",
+                "operationId": "getPet",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
                         "explode": false,
                         "example": {
                             "role": "admin",

--- a/test/parameter_variations_swagger.json
+++ b/test/parameter_variations_swagger.json
@@ -94,6 +94,23 @@
             }
         },
         "/pets/{id}": {
+            "parameters": [
+                {
+                    "name": "id",
+                    "in": "path",
+                    "explode": false,
+                    "schema": {
+                        "type": "integer"
+                    }
+                },
+                {
+                    "name": "X-MYHEADER",
+                    "in": "header",
+                    "schema": {
+                        "type": "string"
+                    }
+                }
+            ],
             "get": {
                 "description": "Get Pets from store",
                 "operationId": "getPet",
@@ -109,6 +126,13 @@
                         },
                         "schema": {
                             "type": "object"
+                        }
+                    },
+                    {
+                        "name": "X-MYHEADER",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     {

--- a/test/test.js
+++ b/test/test.js
@@ -1302,3 +1302,94 @@ test('Path parameter with template /pets/{id*} with array value', function (t) {
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('Path parameter with template /pets/{.id} with primitive value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: 5,
+    style: 'label',
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '/pets/.5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{.id*} with primitive value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: 5,
+    explode: true,
+    style: 'label',
+    locationOfExample: 'example',
+    expectedString: '/pets/.5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+test('Path parameter with template /pets/{.id} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    style: 'label',
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '/pets/.role,admin,firstName,Alex,age,34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{.id*} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: true,
+    style: 'label',
+    locationOfExample: 'example',
+    expectedString: '/pets/.role=admin.firstName=Alex.age=34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{.id} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: false,
+    style: 'label',
+    locationOfExample: 'example',
+    expectedString: 'pets/.3,4,5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{.id*} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: true,
+    style: 'label',
+    locationOfExample: 'example',
+    expectedString: 'pets/.3.4.5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1512,3 +1512,63 @@ test('Path parameter with template /pets/{;id*} with array value', function (t) 
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('Header parameter with template {id} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: "--header 'id: role,admin,firstName,Alex,age,34'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Header parameter with template {id*} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: true,
+    locationOfExample: 'example',
+    expectedString: "--header 'id: role=admin,firstName=Alex,age=34'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Header parameter with template {id} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: "--header 'id: 3,4,5'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Header parameter with template {id*} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: true,
+    locationOfExample: 'example',
+    expectedString: "--header 'id: 3,4,5'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1393,3 +1393,94 @@ test('Path parameter with template /pets/{.id*} with array value', function (t) 
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('Path parameter with template /pets/{;id} with primitive value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: 5,
+    style: 'matrix',
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '/pets/;id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{;id*} with primitive value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: 5,
+    explode: true,
+    style: 'matrix',
+    locationOfExample: 'example',
+    expectedString: '/pets/;id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+test('Path parameter with template /pets/{;id} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    style: 'matrix',
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '/pets/;id=role,admin,firstName,Alex,age,34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{;id*} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: true,
+    style: 'matrix',
+    locationOfExample: 'example',
+    expectedString: '/pets/;role=admin;firstName=Alex;age=34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{;id} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: false,
+    style: 'matrix',
+    locationOfExample: 'example',
+    expectedString: 'pets/;id=3,4,5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{;id*} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: true,
+    style: 'matrix',
+    locationOfExample: 'example',
+    expectedString: 'pets/;id=3;id=4;id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1186,7 +1186,7 @@ const singlePetScenario = {
 test('Query parameter with template {?id} with object value', function (t) {
   const testOptions = Object.assign({}, allPetsScenario, {
     in: 'query',
-    parameterName: 'objectValue',
+    parameterName: 'id',
     value: {
       role: 'admin',
       firstName: 'Alex',
@@ -1194,7 +1194,7 @@ test('Query parameter with template {?id} with object value', function (t) {
     },
     explode: false,
     locationOfExample: 'default',
-    expectedString: 'objectValue=role%2Cadmin%2CfirstName%2CAlex%2Cage%2C34',
+    expectedString: 'id=role%2Cadmin%2CfirstName%2CAlex%2Cage%2C34',
   });
   runParameterTest(t, testOptions);
   t.end();
@@ -1203,7 +1203,7 @@ test('Query parameter with template {?id} with object value', function (t) {
 test('Query parameter with template {?id*} with object value', function (t) {
   const testOptions = Object.assign({}, allPetsScenario, {
     in: 'query',
-    parameterName: 'objectValue',
+    parameterName: 'id',
     value: {
       role: 'admin',
       firstName: 'Alex',
@@ -1220,11 +1220,11 @@ test('Query parameter with template {?id*} with object value', function (t) {
 test('Query parameter with template {?id} with array value', function (t) {
   const testOptions = Object.assign({}, allPetsScenario, {
     in: 'query',
-    parameterName: 'objectValue',
+    parameterName: 'id',
     value: [3, 4, 5],
     explode: false,
     locationOfExample: 'default',
-    expectedString: 'objectValue=3%2C4%2C5',
+    expectedString: 'id=3%2C4%2C5',
   });
   runParameterTest(t, testOptions);
   t.end();
@@ -1233,11 +1233,71 @@ test('Query parameter with template {?id} with array value', function (t) {
 test('Query parameter with template {?id*} with array value', function (t) {
   const testOptions = Object.assign({}, allPetsScenario, {
     in: 'query',
-    parameterName: 'objectValue',
+    parameterName: 'id',
     value: [3, 4, 5],
     explode: true,
     locationOfExample: 'default',
-    expectedString: 'objectValue=3&objectValue=4&objectValue=5',
+    expectedString: 'id=3&id=4&id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{id} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '/pets/role,admin,firstName,Alex,age,34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{id*} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: true,
+    locationOfExample: 'example',
+    expectedString: '/pets/role=admin,firstName=Alex,age=34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{id} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: 'pets/3,4,5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with template /pets/{id*} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: true,
+    locationOfExample: 'example',
+    expectedString: 'pets/3,4,5',
   });
   runParameterTest(t, testOptions);
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -1701,3 +1701,16 @@ test('Cookie parameter with template id={id} with array value', function (t) {
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('A reference in an examples object is resolved', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterVariationsAPI,
+    '/animals',
+    'get',
+    ['shell_curl']
+  );
+
+  const snippet = result.snippets[0].content;
+  t.match(snippet, /tags=dog%2Ccat/);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1645,3 +1645,59 @@ test('Header parameter defined in operation (not in path) object', function (t) 
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('Cookie parameter with explode = true', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'cookie',
+    parameterName: 'id',
+    value: 5,
+    explode: true,
+    locationOfExample: 'example',
+    expectedString: '--cookie id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Cookie parameter with template id={id} with primitive value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'cookie',
+    parameterName: 'id',
+    value: 5,
+    explode: false,
+    locationOfExample: 'examples',
+    expectedString: '--cookie id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Cookie parameter with template id={id} with object value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'cookie',
+    parameterName: 'id',
+    value: {
+      role: 'admin',
+      firstName: 'Alex',
+      age: 34,
+    },
+    explode: false,
+    locationOfExample: 'default',
+    expectedString: '--cookie id=role%2Cadmin%2CfirstName%2CAlex%2Cage%2C34',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Cookie parameter with template id={id} with array value', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'cookie',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    explode: false,
+    locationOfExample: 'example',
+    expectedString: '--cookie id=3%2C4%2C5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -780,7 +780,7 @@ test('Query: /users{?id} with id=[3,4,5], spaceDelimited', function (t) {
     explode: false,
   };
 
-  const expected = [{ name: 'id', value: '3%204%205' }];
+  const expected = [{ name: 'id', value: '3 4 5' }];
   const actual = createHarParameterObjects(parameter, [3, 4, 5]);
   t.deepEqual(actual, expected);
   t.end();
@@ -1238,6 +1238,34 @@ test('Query parameter with template {?id*} with array value', function (t) {
     explode: true,
     locationOfExample: 'default',
     expectedString: 'id=3&id=4&id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Query parameter with with spaceDelimited style array value', function (t) {
+  const testOptions = Object.assign({}, allPetsScenario, {
+    in: 'query',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    style: 'spaceDelimited',
+    explode: false,
+    locationOfExample: 'default',
+    expectedString: 'id=3%204%205',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Query parameter with pipeDelimited array value', function (t) {
+  const testOptions = Object.assign({}, allPetsScenario, {
+    in: 'query',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    style: 'pipeDelimited',
+    explode: false,
+    locationOfExample: 'default',
+    expectedString: 'id=3%7C4%7C5',
   });
   runParameterTest(t, testOptions);
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,7 @@ test('An invalid target should result in error', function (t) {
   try {
     const result = OpenAPISnippets.getSnippets(BloggerOpenAPI, ['node_asfd']);
     console.log(result);
+    t.end();
   } catch (err) {
     t.equal(err.toString(), 'Error: Invalid target: node_asfd');
   }
@@ -1604,6 +1605,42 @@ test('Header parameter with sample given by examples key', function (t) {
     value: [3, 4, 5],
     locationOfExample: 'examples',
     expectedString: "--header 'id: 3,4,5'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Header parameter defined in operation overrides header parameter of same name in path', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterVariationsAPI,
+    '/pets/{id}',
+    'get',
+    ['shell_curl']
+  );
+  const snippet = result.snippets[0].content;
+  t.match(snippet, /--header 'X-MYHEADER: SOME_STRING_VALUE'/);
+  t.end();
+});
+
+test('Path parameter defined in operation overrides header parameter of same name in path', function (t) {
+  const result = OpenAPISnippets.getEndpointSnippets(
+    ParameterVariationsAPI,
+    '/pets/{id}',
+    'get',
+    ['shell_curl']
+  );
+  const snippet = result.snippets[0].content;
+  t.match(snippet, /\/pets\/role,admin,firstName,Alex,age,34/);
+  t.end();
+});
+
+test('Header parameter defined in operation (not in path) object', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'X-MYHEADER',
+    value: [3, 4, 5],
+    locationOfExample: 'examples',
+    expectedString: "--header 'X-MYHEADER: 3,4,5'",
   });
   runParameterTest(t, testOptions);
   t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,8 @@
 const test = require('tape');
 const OpenAPISnippets = require('../index');
 
+const { createHarParameterObjects } = require('../openapi-to-har');
+
 const InstagramOpenAPI = require('./instagram_swagger.json');
 const BloggerOpenAPI = require('./blogger_swagger.json');
 const GitHubOpenAPI = require('./github_swagger.json');
@@ -323,5 +325,730 @@ test('Testing the application/x-www-form-urlencoded example case', function (t) 
   const snippet = result.snippets[0].content;
   t.match(snippet, /.*--data 'id=id\+example\+value'.*/);
   t.match(snippet, /.*--data 'secret=secret\+example\+value'.*/);
+  t.end();
+});
+
+// Tests of createHarParameterObject
+
+// First a set of path parameter tests from here: https://swagger.io/docs/specification/serialization/#path
+
+test('Path: test that style and explode default correctly (to "simple" and "false") when neither is specified for path', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+  };
+
+  const expected = [{ name: 'id', value: '1,2,3' }];
+  const actual = createHarParameterObjects(parameter, [1, 2, 3]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// Simple style tests:
+
+test('Path: /users/{id*} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{id*} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{id*} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: 'role=admin,firstName=Alex,age=34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{id} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{id} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{id} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: 'role,admin,firstName,Alex,age,34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// Label style tests
+
+test('Path: /users/{.id*} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '.5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{.id*} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '.3.4.5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{.id*} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '.role=admin.firstName=Alex.age=34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{.id} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '.5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{.id} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '.3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{.id} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'label',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '.role,admin,firstName,Alex,age,34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// Matrix style tests
+
+test('Path: /users/{;id*} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: ';id=5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{;id*} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: ';id=3;id=4;id=5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{;id*} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: ';role=admin;firstName=Alex;age=34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{;id} with id=5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: ';id=5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{;id} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: ';id=3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Path: /users/{;id} with id= {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'path',
+    style: 'matrix',
+    explode: false,
+  };
+
+  const expected = [
+    { name: 'id', value: ';id=role,admin,firstName,Alex,age,34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+//// Query Parameters: Test cases from https://swagger.io/docs/specification/serialization/#query
+
+// Form Tests
+
+test('Query: /users{?id*} with id= 5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id*} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: true,
+  };
+
+  const expected = [
+    { name: 'id', value: '3' },
+    { name: 'id', value: '4' },
+    { name: 'id', value: '5' },
+  ];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id*} with id={"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: true,
+  };
+
+  const expected = [
+    { name: 'role', value: 'admin' },
+    { name: 'firstName', value: 'Alex' },
+    { name: 'age', value: '34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id} with id= 5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id} with id=[3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id} with id={"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: 'role,admin,firstName,Alex,age,34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: test that style and explode default correctly (to "form" and "true") when neither is specified for query', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+  };
+
+  const expected = [
+    { name: 'firstName', value: 'Alex' },
+    { name: 'age', value: '34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// Space Delimited Tests
+// Note: There are less scenarios for this and no special URI Template
+
+test('Query: /users{?id*} with id=[3,4,5], spaceDelimited', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'spaceDelimited',
+    explode: true,
+  };
+
+  const expected = [
+    { name: 'id', value: '3' },
+    { name: 'id', value: '4' },
+    { name: 'id', value: '5' },
+  ];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id} with id=[3,4,5], spaceDelimited', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'spaceDelimited',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '3%204%205' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// Pipe Delimited Tests
+// Note: There are less scenarios for this and no special URI Template
+
+test('Query: /users{?id*} with id=[3,4,5], pipeDelimited', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'pipeDelimited',
+    explode: true,
+  };
+
+  const expected = [
+    { name: 'id', value: '3' },
+    { name: 'id', value: '4' },
+    { name: 'id', value: '5' },
+  ];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Query: /users{?id} with id=[3,4,5], pipeDelimited', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'pipeDelimited',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '3|4|5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+// DeepObject
+// Spec doesn't say what to do if explode false. We just assume deepOject ignores explode
+// as no alternative serialization is defined when explode is false.
+
+test('Query: deepObject with id={"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'query',
+    style: 'deepObject',
+  };
+
+  const expected = [
+    {
+      name: 'id[role]',
+      value: 'admin',
+    },
+    {
+      name: 'id[firstName]',
+      value: 'Alex',
+    },
+    {
+      name: 'id[age]',
+      value: '34',
+    },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+//// Header Parameters https://swagger.io/docs/specification/serialization/#header
+
+test('Header: {id} with X-MyHeader = 5', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [{ name: 'X-MyHeader', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: {id} with X-MyHeader = [3,4,5]', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [{ name: 'X-MyHeader', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: {id} with X-MyHeader = {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: false,
+  };
+
+  const expected = [
+    { name: 'X-MyHeader', value: 'role,admin,firstName,Alex,age,34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: {id*} with X-MyHeader = 5', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [{ name: 'X-MyHeader', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: {id*} with X-MyHeader = [3,4,5]', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [{ name: 'X-MyHeader', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: {id*} with X-MyHeader = {"role": "admin", "firstName": "Alex", "age": 34}', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+    style: 'simple',
+    explode: true,
+  };
+
+  const expected = [
+    { name: 'X-MyHeader', value: 'role=admin,firstName=Alex,age=34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Header: Test that style and explode default to simple/false when not provided', function (t) {
+  const parameter = {
+    name: 'X-MyHeader',
+    in: 'header',
+  };
+
+  const expected = [
+    { name: 'X-MyHeader', value: 'role,admin,firstName,Alex,age,34' },
+  ];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+//// Cookie Parameters https://swagger.io/docs/specification/serialization/#cookie
+
+test("Cookie: Test that it doesn't throw an error if style and explode are missing", function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'cookie',
+  };
+
+  let expected = [{ name: 'id', value: '5' }];
+  let actual = createHarParameterObjects(parameter, 5);
+
+  t.deepEqual(actual, expected);
+
+  // At the time of writing the spec doesn't actually show any test cases for exploded arrays or objects
+  // so I assume they are not "legal"
+
+  t.end();
+});
+
+test('Cookie: id = 5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'cookie',
+    style: 'form',
+    explode: true,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Cookie: id={id} with id = 5', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'cookie',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '5' }];
+  const actual = createHarParameterObjects(parameter, 5);
+
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Cookie: id={id} with id = [3,4,5]', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'cookie',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: '3,4,5' }];
+  const actual = createHarParameterObjects(parameter, [3, 4, 5]);
+
+  t.deepEqual(actual, expected);
+  t.end();
+});
+
+test('Cookie: id={id} with id = {role: "admin", firstName: "Alex", age: 34}', function (t) {
+  const parameter = {
+    name: 'id',
+    in: 'cookie',
+    style: 'form',
+    explode: false,
+  };
+
+  const expected = [{ name: 'id', value: 'role,admin,firstName,Alex,age,34' }];
+  const actual = createHarParameterObjects(parameter, {
+    role: 'admin',
+    firstName: 'Alex',
+    age: 34,
+  });
+
+  t.deepEqual(actual, expected);
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1572,3 +1572,39 @@ test('Header parameter with template {id*} with array value', function (t) {
   runParameterTest(t, testOptions);
   t.end();
 });
+
+test('Query parameter with sample given by examples key', function (t) {
+  const testOptions = Object.assign({}, allPetsScenario, {
+    in: 'query',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    locationOfExample: 'examples',
+    expectedString: 'id=3&id=4&id=5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Path parameter with sample given by examples key', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'path',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    locationOfExample: 'examples',
+    expectedString: '/pets/3,4,5',
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});
+
+test('Header parameter with sample given by examples key', function (t) {
+  const testOptions = Object.assign({}, singlePetScenario, {
+    in: 'header',
+    parameterName: 'id',
+    value: [3, 4, 5],
+    locationOfExample: 'examples',
+    expectedString: "--header 'id: 3,4,5'",
+  });
+  runParameterTest(t, testOptions);
+  t.end();
+});


### PR DESCRIPTION
This commit does several related things.

* consider examples for parameter values

  If `example` isn't set for a parameter, then go ahead
  and check for `examples`. If that is present, then use the
  value from the first entry as the parameter value.

  Fix #81

* implement support for explode for array and object

  Fix #83

* Fix 3 test scenarios that showed unexploded form
  parameters when explode should have default to true

  This was documented in #83

* Resolve $ref nodes for header parameters

  Fix #84

* Add a full suite of tests for parameters.

* Add support for cookie parameters

* Handle the merging of path and operation parameters correctly for
  all parameter types, not just query ones.

* Add support for label and matrix style path parameters

* Add support for space and pipe delimited query parameters

* There is support for deepObject style, but the `httpsnippet` library 
  encodes all the special chars so I don't know if that's correct or not.